### PR TITLE
Mailchimp

### DIFF
--- a/assets/css/_mailchimp.styl
+++ b/assets/css/_mailchimp.styl
@@ -1,0 +1,63 @@
+#mc-embedded-subscribe-form.validate
+  padding: 0
+
+.newsletter-label
+  font-size: 1.14em
+  font-weight: 300
+  padding: 0 0 10px
+  margin: 0
+  font-style: italic
+  font-family: 'Roboto', sans-serif;
+
+.privacy
+  font-size: 0.5em
+  font-weight: 300
+  font-style: italic
+  margin: 10px 0
+
+$form-width = 300px
+
+#mc_embed_signup .mc-field-group input.email
+  max-width: $form-width
+  border-color: $gray
+  height: 45px
+  font-size: 1.14em
+  font-family: 'Roboto', sans-serif;
+  float: left
+  clear: none
+  border-top-left-radius: 2px
+  border-bottom-left-radius: 2px
+  border-top-right-radius: 0
+  border-bottom-right-radius: 0
+
+  &:focus
+    outline: none
+
+.mce_inline_error
+  max-width: $form-width
+
+#mc_embed_signup .button.newsletter-submit
+  width: 45px
+  height: 45px
+  float: left
+  clear: none
+  background-color: $gray
+  border-top-left-radius: 0
+  border-bottom-left-radius: 0
+  border-top-right-radius: 2px
+  border-bottom-right-radius: 2px
+  margin: 0
+
+  hover-darken()
+
+  &:hover
+    transition: all .2s ease-in
+
+
+#mc_embed_signup .mc-field-group.newsletter-fields
+  padding-bottom: 0
+
+#mc_embed_signup div#mce-responses.messages
+  margin: 0
+  float: none
+  padding: 0

--- a/assets/css/master.styl
+++ b/assets/css/master.styl
@@ -1,4 +1,5 @@
 @import '_settings'
+@import '_mailchimp'
 
 normalize-css()
 base()
@@ -7,6 +8,9 @@ $padding-left = 100px
 
 *
   box-sizing: border-box
+
+.group
+  group()
 
 header
   background-color: $black

--- a/views/index.jade
+++ b/views/index.jade
@@ -22,17 +22,18 @@ block content
         #mc_embed_signup
           form#mc-embedded-subscribe-form.validate(action='//vizcab.us12.list-manage.com/subscribe/post?u=510631967758d21e870f41610&id=6fbd5c05fa', method='post', name='mc-embedded-subscribe-form', target='_blank', novalidate='')
             #mc_embed_signup_scroll
-              .mc-field-group
-                label(for='mce-EMAIL') Email Address 
-                input#mce-EMAIL.required.email(type='email', value='', name='EMAIL')
-              #mce-responses.clear
+              .mc-field-group.newsletter-fields
+                label.newsletter-label(for='mce-EMAIL') Get the every-once-in-a-while Vizcab newsletter
+                .group
+                  input#mce-EMAIL.required.email(type='email', value='', name='EMAIL', placeholder="your email")
+                  input#mc-embedded-subscribe.button.newsletter-submit(type='submit', value='>', name='subscribe')
+              #mce-responses.clear.messages
                 #mce-error-response.response(style='display:none')
                 #mce-success-response.response(style='display:none')
               // real people should not fill this in and expect good things - do not remove this or risk form bot signups
               div(style='position: absolute; left: -5000px;', aria-hidden='true')
                 input(type='text', name='b_510631967758d21e870f41610_6fbd5c05fa', tabindex='-1', value='')
-              .clear
-                input#mc-embedded-subscribe.button(type='submit', value='Subscribe', name='subscribe')
+        p.privacy We won't share your email with others or spam you
         script(type='text/javascript', src='//s3.amazonaws.com/downloads.mailchimp.com/js/mc-validate.js')
         script(type='text/javascript').
           (function($) {window.fnames = new Array(); window.ftypes = new Array();fnames[0]='EMAIL';ftypes[0]='email';fnames[1]='FNAME';ftypes[1]='text';fnames[2]='LNAME';ftypes[2]='text';}(jQuery));var $mcj = jQuery.noConflict(true);

--- a/views/index.jade
+++ b/views/index.jade
@@ -13,4 +13,30 @@ block content
         li: a(href='https://twitter.com/50Fitty') 50Fitty Twitter
         li: a(href='http://questmass101.com') QuestMass 101
 
+        // Begin MailChimp Signup Form
+        link(href='//cdn-images.mailchimp.com/embedcode/classic-081711.css', rel='stylesheet', type='text/css')
+        style(type='text/css').
+          #mc_embed_signup{background:#fff; clear:left; font:14px Helvetica,Arial,sans-serif; }
+          /* Add your own MailChimp form style overrides in your site stylesheet or in this style block.
+          We recommend moving this block and the preceding CSS link to the HEAD of your HTML file. */
+        #mc_embed_signup
+          form#mc-embedded-subscribe-form.validate(action='//vizcab.us12.list-manage.com/subscribe/post?u=510631967758d21e870f41610&id=6fbd5c05fa', method='post', name='mc-embedded-subscribe-form', target='_blank', novalidate='')
+            #mc_embed_signup_scroll
+              .mc-field-group
+                label(for='mce-EMAIL') Email Address 
+                input#mce-EMAIL.required.email(type='email', value='', name='EMAIL')
+              #mce-responses.clear
+                #mce-error-response.response(style='display:none')
+                #mce-success-response.response(style='display:none')
+              // real people should not fill this in and expect good things - do not remove this or risk form bot signups
+              div(style='position: absolute; left: -5000px;', aria-hidden='true')
+                input(type='text', name='b_510631967758d21e870f41610_6fbd5c05fa', tabindex='-1', value='')
+              .clear
+                input#mc-embedded-subscribe.button(type='submit', value='Subscribe', name='subscribe')
+        script(type='text/javascript', src='//s3.amazonaws.com/downloads.mailchimp.com/js/mc-validate.js')
+        script(type='text/javascript').
+          (function($) {window.fnames = new Array(); window.ftypes = new Array();fnames[0]='EMAIL';ftypes[0]='email';fnames[1]='FNAME';ftypes[1]='text';fnames[2]='LNAME';ftypes[2]='text';}(jQuery));var $mcj = jQuery.noConflict(true);
+        // End mc_embed_signup
+      
+
     img.headshot(src='/img/michael.jpg')


### PR DESCRIPTION
Adds Mailchimp form. Closes #2 

![email](https://cloud.githubusercontent.com/assets/1937303/11736191/29530dec-9f99-11e5-9280-398f3869aeb3.gif)

@VizCab With the addition of the input form, I think we need to move up the copy and reduce the padding at the top. It's live in production now you can take a look. Right now, it's still using the default Mailchimp styles for the feedback messages, so let me know how you want to approach that.